### PR TITLE
Add endConnection() method to facilitate a clean express shutdown.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,6 +79,18 @@ MySQLConnectionManager.prototype.createConnection = function(cb) {
 
 }
 
+MySQLConnectionManager.prototype.endConnection = function (cb) {
+
+  debug('Ending database connection')
+
+  this.clearKeepAliveInterval()
+
+  if (this.connection) {
+    this.connection.end(cb)
+  }                                                                                                                                                                 
+
+}
+
 MySQLConnectionManager.prototype.createPool = function(cb) {
 
 	debug('Creating new database connection pool')


### PR DESCRIPTION
Added endConnection() which clears the internal keepalive setInterval and ends the connection or pool.

Can be called to cleanly shut down the manager as part of an express shutdown.
